### PR TITLE
Fix word frequency analysis with no valid words

### DIFF
--- a/components/tools/word-frequency-counter.tsx
+++ b/components/tools/word-frequency-counter.tsx
@@ -76,6 +76,18 @@ export function WordFrequencyCounter() {
 
     // Convert to array and sort by frequency
     const totalWords = words.length;
+    if (totalWords === 0) {
+      setFrequencies([]);
+      setStats({
+        totalWords: 0,
+        uniqueWords: 0,
+        totalCharacters: text.length,
+        averageWordLength: 0
+      });
+      toast.error('No valid words found with the given options');
+      return;
+    }
+
     const frequencies: WordFrequency[] = Array.from(wordCounts.entries())
       .map(([word, count]) => ({
         word,


### PR DESCRIPTION
## Summary
- prevent divide-by-zero when text contains no valid words

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a0d38ec883219810eaf073936656