### PR TITLE
Fix unused beautification split

### DIFF
--- a/components/tools/js-minifier.tsx
+++ b/components/tools/js-minifier.tsx
@@ -71,7 +71,6 @@ export function JsMinifier() {
       } else {
         // Simple JavaScript beautification
         let indentLevel = 0;
-        const lines = result.split(/[;{}]/);
         
         result = input
           .replace(/\s*{\s*/g, ' {\n')


### PR DESCRIPTION
## Summary
- remove unused `lines` variable in JS beautifier

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847a2513c188321bf0c3c6a96c4dabf