### PR TITLE
Add searchTools tests with Vitest

### DIFF
--- a/__tests__/tools-data.test.ts
+++ b/__tests__/tools-data.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { searchTools, tools } from '../lib/tools-data';
+
+describe('searchTools', () => {
+  it('returns all tools when query is empty', () => {
+    const result = searchTools('');
+    expect(result).toEqual(tools);
+  });
+
+  it('matches tools by name', () => {
+    const result = searchTools('Percentage');
+    expect(result.some(t => t.id === 'percentage-calculator')).toBe(true);
+  });
+
+  it('matches tools by description', () => {
+    const result = searchTools('interactive charts');
+    expect(result.some(t => t.id === 'compound-interest-calculator')).toBe(true);
+  });
+
+  it('matches tools by keywords', () => {
+    const result = searchTools('epoch');
+    expect(result.some(t => t.id === 'timestamp-converter')).toBe(true);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@types/crypto-js": "^4.2.2",
@@ -23,5 +24,7 @@
     "terser": "^5.40.0",
     "uuid": "^11.1.0"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "vitest": "^3.2.3"
+  }
 }


### PR DESCRIPTION
## Summary
- add Vitest dev dependency and test script
- create unit tests for `searchTools` covering empty queries and name/description/keyword matches

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6847a25443808321b8c8f33bde6f0589